### PR TITLE
[Sprint3.5/home] refactor: 댓글 조회 리팩터링

### DIFF
--- a/src/main/java/star/common/constants/CommonConstants.java
+++ b/src/main/java/star/common/constants/CommonConstants.java
@@ -4,4 +4,5 @@ public final class CommonConstants {
     public static final String CRITICAL_ERROR_MESSAGE = "서버에서 예상치 못한 에러가 발생하였습니다.";
     public static final int OPTIMISTIC_ATTEMPT_COUNT = 10;
     public static final int MAX_IMAGE_COUNT = 10;
+    public static final long ANONYMOUS_MEMBER_ID = -12345678L;
 }

--- a/src/main/java/star/common/exception/client/InvalidPageableFieldException.java
+++ b/src/main/java/star/common/exception/client/InvalidPageableFieldException.java
@@ -1,0 +1,13 @@
+package star.common.exception.client;
+
+public class InvalidPageableFieldException extends ClientException {
+
+    private static final String ERROR_MESSAGE_PREFIX = """
+            올바르지 않은 필드 입니다.
+            입력한 필드 : 
+            """;
+
+    public InvalidPageableFieldException(String clientParam) {
+        super(ERROR_MESSAGE_PREFIX + clientParam);
+    }
+}

--- a/src/main/java/star/home/board/dto/response/BoardResponse.java
+++ b/src/main/java/star/home/board/dto/response/BoardResponse.java
@@ -18,27 +18,12 @@ public record BoardResponse (
         Integer viewCount,
         LocalDateTime createdAt,
         Integer likeCount,
-        Integer commentCount,
-        List<Comment> comments
+        Integer commentCount
 ) {
     @Builder
     public record Author (
             Long id,
             String imageUrl,
             String nickname
-    ) {
-
-    }
-
-    @Builder
-    public record Comment (
-            Long id,
-            Author author,
-            Boolean isViewerAuthor,
-            Boolean isCommenterAuthor,
-            String content,
-            LocalDateTime createdAt,
-            List<Comment> childComments,
-            Integer depth
     ) { }
 }

--- a/src/main/java/star/home/board/mapper/BoardCommentMapper.java
+++ b/src/main/java/star/home/board/mapper/BoardCommentMapper.java
@@ -2,19 +2,20 @@ package star.home.board.mapper;
 
 import java.util.List;
 import star.home.board.dto.response.BoardResponse.Author;
-import star.home.board.dto.response.BoardResponse.Comment;
 import star.home.comment.dto.CommentDTO;
+import star.home.comment.dto.response.CommentResponse;
 
 public class BoardCommentMapper {
 
-    public static List<Comment> toCommentVOs(List<CommentDTO> commentDTOs, Long viewerId, Long authorId) {
+    public static List<CommentResponse> toCommentVOs(List<CommentDTO> commentDTOs, Long viewerId,
+            Long authorId) {
         return commentDTOs.stream()
-                .map(dto -> toCommentVO(dto, viewerId, authorId))
+                .map(dto -> toCommentResponse(dto, viewerId, authorId))
                 .toList();
     }
 
-    private static Comment toCommentVO(CommentDTO dto, Long viewerId, Long authorId) {
-        return Comment.builder()
+    private static CommentResponse toCommentResponse(CommentDTO dto, Long viewerId, Long authorId) {
+        return CommentResponse.builder()
                 .id(dto.getId())
                 .author(Author.builder()
                         .id(dto.getMemberInfoDTO().id())

--- a/src/main/java/star/home/comment/controller/CommentController.java
+++ b/src/main/java/star/home/comment/controller/CommentController.java
@@ -25,7 +25,7 @@ import star.home.comment.service.CommentService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/home/boards/{boardId}")
+@RequestMapping("/home/boards/{boardId}/comments")
 public class CommentController {
 
     private final CreateCommentFacadeService createCommentFacadeService;
@@ -54,7 +54,7 @@ public class CommentController {
                 commentService.getCommentsPage(userDetails.getMemberInfoDTO(), boardId, pageable));
     }
 
-    @PutMapping("/comments/{commentId}")
+    @PutMapping("/{commentId}")
     public ResponseEntity<CommonResponse> updateComment(
             @PathVariable Long boardId,
             @PathVariable Long commentId,
@@ -65,7 +65,7 @@ public class CommentController {
         return ResponseEntity.ok(CommonResponse.success());
     }
 
-    @DeleteMapping("/comments/{commentId}")
+    @DeleteMapping("/{commentId}")
     public ResponseEntity<CommonResponse> softDeleteComment(
             @PathVariable Long boardId,
             @PathVariable Long commentId,

--- a/src/main/java/star/home/comment/controller/CommentController.java
+++ b/src/main/java/star/home/comment/controller/CommentController.java
@@ -2,9 +2,14 @@ package star.home.comment.controller;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -14,30 +19,42 @@ import org.springframework.web.bind.annotation.RestController;
 import star.common.dto.response.CommonResponse;
 import star.common.security.dto.StarUserDetails;
 import star.home.comment.dto.request.CommentRequest;
-import star.home.comment.service.BoardCommentFacadeService;
+import star.home.comment.dto.response.CommentResponse;
+import star.home.comment.service.CreateCommentFacadeService;
 import star.home.comment.service.CommentService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/home/boards")
+@RequestMapping("/home/boards/{boardId}")
 public class CommentController {
-    private final BoardCommentFacadeService boardCommentFacadeService;
+
+    private final CreateCommentFacadeService createCommentFacadeService;
     private final CommentService commentService;
 
-    @PostMapping("/{boardId}")
+    @PostMapping
     public ResponseEntity<CommonResponse> createComment(
             @PathVariable Long boardId,
             @AuthenticationPrincipal StarUserDetails userDetails,
             @RequestBody CommentRequest request
     ) {
-        Long commentId = boardCommentFacadeService.createComment(userDetails.getMemberInfoDTO(),
+        Long commentId = createCommentFacadeService.createComment(userDetails.getMemberInfoDTO(),
                 request, boardId);
         URI location = URI.create("/home/boards/" + boardId + "/comments/" + commentId);
 
         return ResponseEntity.created(location).body(CommonResponse.success());
     }
 
-    @PutMapping("/{boardId}/comments/{commentId}")
+    @GetMapping
+    public ResponseEntity<Page<CommentResponse>> getComments(
+            @AuthenticationPrincipal StarUserDetails userDetails,
+            @PathVariable Long boardId,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return ResponseEntity.ok(
+                commentService.getCommentsPage(userDetails.getMemberInfoDTO(), boardId, pageable));
+    }
+
+    @PutMapping("/comments/{commentId}")
     public ResponseEntity<CommonResponse> updateComment(
             @PathVariable Long boardId,
             @PathVariable Long commentId,
@@ -48,7 +65,7 @@ public class CommentController {
         return ResponseEntity.ok(CommonResponse.success());
     }
 
-    @DeleteMapping("/{boardId}/comments/{commentId}")
+    @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<CommonResponse> softDeleteComment(
             @PathVariable Long boardId,
             @PathVariable Long commentId,

--- a/src/main/java/star/home/comment/dto/response/CommentResponse.java
+++ b/src/main/java/star/home/comment/dto/response/CommentResponse.java
@@ -1,0 +1,18 @@
+package star.home.comment.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import star.home.board.dto.response.BoardResponse.Author;
+
+@Builder
+public record CommentResponse (
+        Long id,
+        Author author,
+        Boolean isViewerAuthor,
+        Boolean isCommenterAuthor,
+        String content,
+        LocalDateTime createdAt,
+        List<CommentResponse> childComments,
+        Integer depth
+) { }

--- a/src/main/java/star/home/comment/model/entity/Comment.java
+++ b/src/main/java/star/home/comment/model/entity/Comment.java
@@ -14,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import star.common.entity.SoftDeletableEntity;
 import star.home.board.model.entity.Board;
 import star.home.comment.model.vo.Content;
@@ -37,6 +38,11 @@ public class Comment extends SoftDeletableEntity {
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "root_comment_id", nullable = false)
+    private Comment rootComment;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parrent_comment_id", nullable = true)
     private Comment parentComment;
@@ -48,7 +54,8 @@ public class Comment extends SoftDeletableEntity {
     private Content content;
 
     @Builder
-    public Comment(Member author, Board board, Comment parentComment, Integer depth, String content) {
+    public Comment(Member author, Board board, Comment parentComment, Integer depth,
+            String content) {
         this.author = author;
         this.board = board;
         this.parentComment = parentComment;
@@ -57,6 +64,7 @@ public class Comment extends SoftDeletableEntity {
     }
 
     public void updateComment(String content) {
-        this.content =  new Content(content);
+        this.content = new Content(content);
     }
+
 }

--- a/src/main/java/star/home/comment/repository/CommentRepository.java
+++ b/src/main/java/star/home/comment/repository/CommentRepository.java
@@ -2,19 +2,21 @@ package star.home.comment.repository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import star.home.comment.model.entity.Comment;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    Optional<Comment> getCommentByIdAndBoardId(Long id, Long boardId);
-    List<Comment> getCommentsByBoardIdAndDepthOrderByCreatedAtAsc(Long boardId, Integer depth);
 
-    @Query("select max(c.depth) from Comment c where c.board.id = :boardId")
-    Integer findTopDepthByBoardId(@Param("boardId") Long boardId);
+    Optional<Comment> getCommentByIdAndBoardId(Long id, Long boardId);
 
     void deleteCommentsByBoardId(Long boardId);
+
+    Boolean existsByBoardId(Long boardId);
+
+    List<Comment> getCommentsByBoardIdAndRootCommentIdIn(Long boardId, List<Long> rootCommentIds);
+
+    List<Comment> getBoardsByBoardIdAndDepth(Long boardId, Integer rootCommentDepth, Pageable pageable);
 }

--- a/src/main/java/star/home/comment/service/CommentService.java
+++ b/src/main/java/star/home/comment/service/CommentService.java
@@ -1,147 +1,111 @@
 package star.home.comment.service;
 
+import static star.common.constants.CommonConstants.ANONYMOUS_MEMBER_ID;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.OptimisticLockException;
-import jakarta.persistence.PersistenceContext;
+import jakarta.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import star.common.constants.CommonConstants;
-import star.common.exception.client.YouAreNotAuthorException;
 import star.common.exception.server.InternalServerException;
 import star.common.service.BaseRetryRecoverService;
+import star.home.board.mapper.BoardCommentMapper;
 import star.home.board.model.entity.Board;
 import star.home.comment.dto.CommentDTO;
 import star.home.comment.dto.request.CommentRequest;
-import star.home.comment.exception.InvalidIdCommentException;
+import star.home.comment.dto.response.CommentResponse;
 import star.home.comment.model.entity.Comment;
-import star.home.comment.repository.CommentRepository;
+import star.home.comment.service.internal.CommentDataService;
 import star.member.dto.MemberInfoDTO;
-import star.member.model.entity.Member;
-import star.member.service.MemberService;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService extends BaseRetryRecoverService {
 
-    private static final Integer TOP_LEVEL_COMMENT_DEPTH = 0;
-
-    private final MemberService memberService;
-    private final CommentRepository commentRepository;
-
-    @PersistenceContext
-    private EntityManager entityManager;
+    private final CommentDataService commentDataService;
 
     @Transactional
     public Long createComment(MemberInfoDTO memberInfoDTO, CommentRequest request, Board board) {
-        Member member = memberService.getMemberEntityById(memberInfoDTO.id());
-        Comment parentComment = null;
-
-        int depth = TOP_LEVEL_COMMENT_DEPTH;
-
-        if (request.parentCommentId() != null) {
-            parentComment = commentRepository.getCommentByIdAndBoardId(request.parentCommentId(),
-                            board.getId())
-                    .orElseThrow(InvalidIdCommentException::new);
-            depth = parentComment.getDepth() + 1;
-        }
-
-        Comment comment = Comment.builder()
-                .board(board)
-                .parentComment(parentComment)
-                .author(member)
-                .depth(depth)
-                .content(request.content())
-                .build();
-
-        increaseCommentCount(board);
-        commentRepository.save(comment);
-
-        return comment.getId();
+        return commentDataService.createComment(memberInfoDTO, request, board);
     }
 
-    //BFS 적으로 트리를 탐색
     @Transactional(readOnly = true)
-    public List<CommentDTO> getComments(Long boardId) {
+    public Page<CommentResponse> getCommentsPage(@Nullable MemberInfoDTO memberInfoDTO,
+            Long boardId, Pageable pageable) {
 
-        List<CommentDTO> commentDTOList = new ArrayList<>();
-        Integer maxDepth = commentRepository.findTopDepthByBoardId(boardId);
+        boolean haveComment = commentDataService.existsComment(boardId);
 
-        if (maxDepth == null) {
-            maxDepth = TOP_LEVEL_COMMENT_DEPTH - 1;
+        if (!haveComment) {
+            return new PageImpl<>(new ArrayList<>());
         }
 
-        for (int i = TOP_LEVEL_COMMENT_DEPTH; i <= maxDepth; i++) {
-            List<Comment> iLevelCommentList = commentRepository.getCommentsByBoardIdAndDepthOrderByCreatedAtAsc(
-                    boardId, i);
+        //fetchType이 LAZY 라서 성능 문제 피해갈 수 있음
+        List<Comment> rootComments = commentDataService.getRootCommentEntities(boardId, pageable);
+        List<Long> rootCommentIds = rootComments.stream().map(Comment::getId).toList();
+        List<Comment> notRootComments = commentDataService.getChildCommentEntitiesUsingRootCommentIds(
+                boardId, rootCommentIds);
+        List<CommentDTO> commentDTOs = makeCommentDTOList(rootComments, notRootComments);
 
-            if (i == TOP_LEVEL_COMMENT_DEPTH) {
-                iLevelCommentList.forEach(comment -> commentDTOList.add(CommentDTO.from(comment)));
-                continue;
-            }
-            findParentAndAllocate(iLevelCommentList, commentDTOList);
-        }
-        return commentDTOList;
+        Long viewerId = (memberInfoDTO != null) ? memberInfoDTO.id() : ANONYMOUS_MEMBER_ID;
+        Long authorId = rootComments.getFirst().getAuthor().getId();
+
+        List<CommentResponse> commentResponseList = BoardCommentMapper.toCommentVOs(commentDTOs,
+                viewerId, authorId);
+
+        return new PageImpl<>(commentResponseList, pageable, commentDTOs.size());
     }
 
     @Transactional
     public void updateComment(Long boardId, Long commentId, MemberInfoDTO memberInfoDTO,
             CommentRequest request) {
-        Comment comment = commentRepository.getCommentByIdAndBoardId(commentId, boardId)
-                .orElseThrow(InvalidIdCommentException::new);
-
-        if (!comment.getAuthor().getId().equals(memberInfoDTO.id())) {
-            throw new YouAreNotAuthorException();
-        }
-
-        comment.updateComment(request.content());
-    }
-
-    @Transactional
-    public void hardDeleteComments(Long boardId) {
-        commentRepository.deleteCommentsByBoardId(boardId);
+        commentDataService.updateComment(boardId, commentId, memberInfoDTO, request);
     }
 
     @Transactional
     public void softDeleteComment(Long boardId, Long commentId, MemberInfoDTO memberInfoDTO) {
-        Comment comment = commentRepository.getCommentByIdAndBoardId(commentId, boardId)
-                .orElseThrow(InvalidIdCommentException::new);
+        commentDataService.softDeleteComment(boardId, commentId, memberInfoDTO);
+    }
 
-        if (!comment.getAuthor().getId().equals(memberInfoDTO.id())) {
-            throw new YouAreNotAuthorException();
+    @Transactional
+    public void hardDeleteAllComments(Long boardId) {
+        commentDataService.hardDeleteAllComments(boardId);
+    }
+
+
+    private List<CommentDTO> makeCommentDTOList(List<Comment> rootComments,
+            List<Comment> notRootComments) {
+        List<CommentDTO> result = new ArrayList<>();
+
+        //Key == Comment의 ID
+        Map<Long, CommentDTO> CommentsMap = new HashMap<>();
+
+        rootComments.forEach(rootComment -> {
+            CommentDTO rootCommentDTO = CommentDTO.from(rootComment);
+            CommentsMap.put(rootComment.getId(), rootCommentDTO);
+            result.add(rootCommentDTO);
+        });
+
+        for (Comment iLevelComment : notRootComments) {
+            CommentDTO iLevelCommentDTO = CommentDTO.from(iLevelComment);
+            Long iLevelCommentId = iLevelComment.getId();
+            Long parentCommentId = iLevelComment.getParentComment().getId();
+            CommentDTO parentDTO = CommentsMap.get(parentCommentId);
+
+            if (parentDTO == null) {
+                throw new InternalServerException(
+                        "id가 %d인 부모 댓글을 찾을 수 없습니다.".formatted(parentCommentId));
+            }
+            CommentsMap.put(iLevelCommentId, iLevelCommentDTO);
+            parentDTO.addChildCommentDTO(iLevelCommentDTO);
         }
 
-        comment.markAsDeprecated();
+        return result;
     }
 
-    @Retryable(
-            retryFor = OptimisticLockException.class,
-            maxAttempts = CommonConstants.OPTIMISTIC_ATTEMPT_COUNT,
-            backoff = @Backoff(delay = 100)
-    )
-    private void increaseCommentCount(Board board) {
-        board.increaseCommentCount();
-        entityManager.flush();
-    }
-
-    private void findParentAndAllocate(List<Comment> iLevelCommentList,
-            List<CommentDTO> commentDTOList) {
-        for (Comment notTopLevelComment : iLevelCommentList) {
-            Long parentCommentId = notTopLevelComment.getParentComment().getId();
-
-            CommentDTO foundParentCommentDTO = commentDTOList.stream()
-                    .filter(commentDTO -> commentDTO.getId().equals(parentCommentId))
-                    .findFirst()
-                    .orElseThrow(() -> new InternalServerException(
-                            "%d인 부모 댓글을 찾으려 했으나 못찾음".formatted(parentCommentId)));
-
-            foundParentCommentDTO.addChildCommentDTO(CommentDTO.from(notTopLevelComment));
-
-        }
-    }
 }

--- a/src/main/java/star/home/comment/service/CreateCommentFacadeService.java
+++ b/src/main/java/star/home/comment/service/CreateCommentFacadeService.java
@@ -10,7 +10,7 @@ import star.member.dto.MemberInfoDTO;
 
 @Service
 @RequiredArgsConstructor
-public class BoardCommentFacadeService { //순환참조 때매 만듦
+public class CreateCommentFacadeService { //순환참조 때매 만듦
     private final BoardService boardService;
     private final CommentService commentService;
 

--- a/src/main/java/star/home/comment/service/internal/CommentDataService.java
+++ b/src/main/java/star/home/comment/service/internal/CommentDataService.java
@@ -1,0 +1,125 @@
+package star.home.comment.service.internal;
+
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.OptimisticLockException;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import star.common.constants.CommonConstants;
+import star.common.exception.client.YouAreNotAuthorException;
+import star.common.service.BaseRetryRecoverService;
+import star.home.board.model.entity.Board;
+import star.home.comment.dto.request.CommentRequest;
+import star.home.comment.exception.InvalidIdCommentException;
+import star.home.comment.model.entity.Comment;
+import star.home.comment.repository.CommentRepository;
+import star.member.dto.MemberInfoDTO;
+import star.member.model.entity.Member;
+import star.member.service.MemberService;
+
+@Service
+@RequiredArgsConstructor
+public class CommentDataService {
+
+    private static final Integer ROOT_COMMENT_DEPTH = 0;
+
+    private final MemberService memberService;
+    private final CommentRepository commentRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional(readOnly = true)
+    public Boolean existsComment(Long boardId) {
+        return commentRepository.existsByBoardId(boardId);
+    }
+
+    @Transactional
+    public Long createComment(MemberInfoDTO memberInfoDTO, CommentRequest request, Board board) {
+        Member member = memberService.getMemberEntityById(memberInfoDTO.id());
+        Comment parentComment = null;
+        Comment rootComment = null;
+
+        int depth = ROOT_COMMENT_DEPTH;
+
+        if (request.parentCommentId() != null) {
+            parentComment = commentRepository.getCommentByIdAndBoardId(request.parentCommentId(),
+                            board.getId())
+                    .orElseThrow(InvalidIdCommentException::new);
+            rootComment = parentComment.getRootComment();
+            depth = parentComment.getDepth() + 1;
+        }
+
+        Comment comment = Comment.builder()
+                .board(board)
+                .parentComment(parentComment)
+                .author(member)
+                .depth(depth)
+                .content(request.content())
+                .build();
+
+        comment.setRootComment(Objects.requireNonNullElse(rootComment, comment));
+
+        increaseCommentCount(board);
+        commentRepository.save(comment);
+
+        return comment.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Comment> getRootCommentEntities(Long boardId, Pageable pageable) {
+        return commentRepository.getBoardsByBoardIdAndDepth(boardId, ROOT_COMMENT_DEPTH, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Comment> getChildCommentEntitiesUsingRootCommentIds(Long boardId, List<Long> rootCommentIds) {
+        return commentRepository.getCommentsByBoardIdAndRootCommentIdIn(boardId, rootCommentIds);
+    }
+
+    @Transactional
+    public void updateComment(Long boardId, Long commentId, MemberInfoDTO memberInfoDTO,
+            CommentRequest request) {
+        Comment comment = commentRepository.getCommentByIdAndBoardId(commentId, boardId)
+                .orElseThrow(InvalidIdCommentException::new);
+
+        if (!comment.getAuthor().getId().equals(memberInfoDTO.id())) {
+            throw new YouAreNotAuthorException();
+        }
+
+        comment.updateComment(request.content());
+    }
+
+    @Transactional
+    public void hardDeleteAllComments(Long boardId) {
+        commentRepository.deleteCommentsByBoardId(boardId);
+    }
+
+    @Transactional
+    public void softDeleteComment(Long boardId, Long commentId, MemberInfoDTO memberInfoDTO) {
+        Comment comment = commentRepository.getCommentByIdAndBoardId(commentId, boardId)
+                .orElseThrow(InvalidIdCommentException::new);
+
+        if (!comment.getAuthor().getId().equals(memberInfoDTO.id())) {
+            throw new YouAreNotAuthorException();
+        }
+
+        comment.markAsDeprecated();
+    }
+
+    @Retryable(
+            retryFor = OptimisticLockException.class,
+            maxAttempts = CommonConstants.OPTIMISTIC_ATTEMPT_COUNT,
+            backoff = @Backoff(delay = 100)
+    )
+    private void increaseCommentCount(Board board) {
+        board.increaseCommentCount();
+        entityManager.flush();
+    }
+}


### PR DESCRIPTION
1. 기존 API는 게시글 조회 시 게시글과 댓글을 한번에 조회한다.
2. 댓글 조회 시 List 구조를 사용하여 탐색하는 불필요한 로직이 시간복잡도를 O(n^2)으로 만든다.
3. 이는 성능 이슈가 예상되었다.
4. 따라서 Pageable 객체로 댓글 일부분을 조회하고
5. List -> Map 리팩터링으로 시간복잡도 O(n) 향상시키는 리팩터링을 하였다.
6. 또한, 게시글 조회와 댓글 조회 API를 분리하였다.